### PR TITLE
Fix condition for single rows reports

### DIFF
--- a/src/datastudio/components/datasources/CustomTwigTemplateQueryDataSource.php
+++ b/src/datastudio/components/datasources/CustomTwigTemplateQueryDataSource.php
@@ -175,24 +175,22 @@ class CustomTwigTemplateQueryDataSource extends DataSource
 
         // If we don't have default labels, we will use the first row as for our column headers
         // We do so by making the first row the keys of the second row
-        if (empty($labels) && is_countable($rows) && count($rows) === 0) {
-            return;
-        }
+        if (empty($labels) && (is_countable($rows) ? count($rows) : 0)) {
+            $headerRow = [];
 
-        $headerRow = [];
+            /** @var array $firstRowColumns */
+            $firstRowColumns = array_shift($rows);
 
-        /** @var array $firstRowColumns */
-        $firstRowColumns = array_shift($rows);
+            if (is_countable($firstRowColumns) ? count($firstRowColumns) : 0) {
+                $secondRow = array_shift($rows);
 
-        if (is_countable($firstRowColumns) && count($firstRowColumns) > 0) {
-            $secondRow = array_shift($rows);
-
-            foreach ($firstRowColumns as $key => $column) {
-                $headerRow[$column] = $secondRow[$key];
+                foreach ($firstRowColumns as $key => $column) {
+                    $headerRow[$column] = $secondRow[$key];
+                }
             }
-        }
 
-        array_unshift($rows, $headerRow);
+            array_unshift($rows, $headerRow);
+        }
     }
 
     /**


### PR DESCRIPTION
While cleaning up the code for the 5.x update, the plugin developer may have made a mistake, causing the logic with conditions to break. Since this is the case with a single row, the 5.x code will always terminate with an error.

To fix this, we are restoring the version of the code for the `processHeaderRow` method that was in the 4.x version.

This should help us fix the broken logic for our custom reports.

This PR addresses issue:
ADD_GITHUB_ISSUE_LINK_HERE

This pull request adds/removes/changes:

1.

Signature, _(add an `[x]` within each checkbox to confirm)_

- [ ] I have linked to the Sprout Plugin Github Issue this PR resolves
- [ ] I have described what this PR adds/removes/changes

<!-------------------------------------------------------------
Report issues in the repository for the plugin where the issue was encountered. If no issue exists, first create an issue describing the problem in the appropriate plugin repository and link to the issue above.
e.g. https://github.com/barrelstrength/craft-sprout-plugin-name/123
--------------------------------------------------------------->
